### PR TITLE
Description Updates

### DIFF
--- a/Items/Eqp/Prescriptions.cs
+++ b/Items/Eqp/Prescriptions.cs
@@ -66,8 +66,7 @@ namespace ThinkInvisible.ClassicItems {
 
         private string FormatNewLangDesc()
         {
-            string desc = "";
-            desc += "While active, increases";
+            string desc = "While active, increases";
             if (dmgBoost > 0f) desc += $" <style=cIsDamage>base damage by {dmgBoost:N0} points</style>";
             if (dmgBoost > 0f && aSpdBoost > 0f) desc += " and";
             if (aSpdBoost > 0f) desc += $" <style=cIsDamage>attack speed by {Pct(aSpdBoost)}</style>";
@@ -78,8 +77,7 @@ namespace ThinkInvisible.ClassicItems {
 
         private string FormatNewLangPickup()
         {
-            string desc = "";
-            desc += "Increase";
+            string desc = "Increase";
             if (dmgBoost > 0f) desc += $" damage";
             if (dmgBoost > 0f && aSpdBoost > 0f) desc += " and";
             if (aSpdBoost > 0f) desc += $" attack speed";

--- a/Items/Eqp/Prescriptions.cs
+++ b/Items/Eqp/Prescriptions.cs
@@ -21,9 +21,9 @@ namespace ThinkInvisible.ClassicItems {
         public float dmgBoost {get;private set;} = 10f;
 
         public BuffIndex prescriptionsBuff {get;private set;}
-        protected override string NewLangName(string langid = null) => displayName;        
-        protected override string NewLangPickup(string langid = null) => "Increase damage and attack speed for " + duration.ToString("N0") + " seconds.";        
-        protected override string NewLangDesc(string langid = null) => "While active, increases <style=cIsDamage>base damage by " + dmgBoost.ToString("N0") + " points</style> and <style=cIsDamage>attack speed by " + Pct(aSpdBoost) + "</style>. Lasts <style=cIsDamage>" + duration.ToString("N0") + " seconds</style>.";
+        protected override string NewLangName(string langid = null) => displayName;
+        protected override string NewLangPickup(string langid = null) => FormatNewLangPickup();
+        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public Prescriptions() {
@@ -62,6 +62,30 @@ namespace ThinkInvisible.ClassicItems {
             sbdy.AddTimedBuff(prescriptionsBuff, duration);
             if(instance.CheckEmbryoProc(sbdy)) sbdy.AddTimedBuff(prescriptionsBuff, duration);
             return true;
+        }
+
+        private string FormatNewLangDesc()
+        {
+            string desc = "";
+            desc += "While active, increases";
+            if (dmgBoost > 0f) desc += $" <style=cIsDamage>base damage by {dmgBoost:N0} points</style>";
+            if (dmgBoost > 0f && aSpdBoost > 0f) desc += " and";
+            if (aSpdBoost > 0f) desc += $" <style=cIsDamage>attack speed by {Pct(aSpdBoost)}</style>";
+            if (dmgBoost <= 0f && aSpdBoost <= 0f) desc += $" <style=cIsDamage>NOTHING</style>";
+            desc += $". Lasts <style=cIsDamage>{duration:N0} seconds</style>.";
+            return desc;
+        }
+
+        private string FormatNewLangPickup()
+        {
+            string desc = "";
+            desc += "Increase";
+            if (dmgBoost > 0f) desc += $" damage";
+            if (dmgBoost > 0f && aSpdBoost > 0f) desc += " and";
+            if (aSpdBoost > 0f) desc += $" attack speed";
+            if (dmgBoost <= 0f && aSpdBoost <= 0f) desc += $" <style=cIsDamage>NOTHING</style>";
+            desc += $" for {duration:N0} seconds.";
+            return desc;
         }
     }
 }

--- a/Items/Eqp/Prescriptions.cs
+++ b/Items/Eqp/Prescriptions.cs
@@ -22,8 +22,26 @@ namespace ThinkInvisible.ClassicItems {
 
         public BuffIndex prescriptionsBuff {get;private set;}
         protected override string NewLangName(string langid = null) => displayName;
-        protected override string NewLangPickup(string langid = null) => FormatNewLangPickup();
-        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
+        protected override string NewLangPickup(string langid = null)
+        {
+            string desc = "Increase";
+            if (dmgBoost > 0f) desc += $" damage";
+            if (dmgBoost > 0f && aSpdBoost > 0f) desc += " and";
+            if (aSpdBoost > 0f) desc += $" attack speed";
+            if (dmgBoost <= 0f && aSpdBoost <= 0f) desc += $" <style=cIsDamage>NOTHING</style>";
+            desc += $" for {duration:N0} seconds.";
+            return desc;
+        }
+        protected override string NewLangDesc(string langid = null)
+        {
+            string desc = "While active, increases";
+            if (dmgBoost > 0f) desc += $" <style=cIsDamage>base damage by {dmgBoost:N0} points</style>";
+            if (dmgBoost > 0f && aSpdBoost > 0f) desc += " and";
+            if (aSpdBoost > 0f) desc += $" <style=cIsDamage>attack speed by {Pct(aSpdBoost)}</style>";
+            if (dmgBoost <= 0f && aSpdBoost <= 0f) desc += $" <style=cIsDamage>NOTHING</style>";
+            desc += $". Lasts <style=cIsDamage>{duration:N0} seconds</style>.";
+            return desc;
+        }
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public Prescriptions() {
@@ -62,28 +80,6 @@ namespace ThinkInvisible.ClassicItems {
             sbdy.AddTimedBuff(prescriptionsBuff, duration);
             if(instance.CheckEmbryoProc(sbdy)) sbdy.AddTimedBuff(prescriptionsBuff, duration);
             return true;
-        }
-
-        private string FormatNewLangDesc()
-        {
-            string desc = "While active, increases";
-            if (dmgBoost > 0f) desc += $" <style=cIsDamage>base damage by {dmgBoost:N0} points</style>";
-            if (dmgBoost > 0f && aSpdBoost > 0f) desc += " and";
-            if (aSpdBoost > 0f) desc += $" <style=cIsDamage>attack speed by {Pct(aSpdBoost)}</style>";
-            if (dmgBoost <= 0f && aSpdBoost <= 0f) desc += $" <style=cIsDamage>NOTHING</style>";
-            desc += $". Lasts <style=cIsDamage>{duration:N0} seconds</style>.";
-            return desc;
-        }
-
-        private string FormatNewLangPickup()
-        {
-            string desc = "Increase";
-            if (dmgBoost > 0f) desc += $" damage";
-            if (dmgBoost > 0f && aSpdBoost > 0f) desc += " and";
-            if (aSpdBoost > 0f) desc += $" attack speed";
-            if (dmgBoost <= 0f && aSpdBoost <= 0f) desc += $" <style=cIsDamage>NOTHING</style>";
-            desc += $" for {duration:N0} seconds.";
-            return desc;
         }
     }
 }

--- a/Items/Eqp/Snowglobe.cs
+++ b/Items/Eqp/Snowglobe.cs
@@ -31,8 +31,22 @@ namespace ThinkInvisible.ClassicItems {
 
         private GameObject snowglobeControllerPrefab;
         protected override string NewLangName(string langid = null) => displayName;
-        protected override string NewLangPickup(string langid = null) => FormatNewLangPickup();
-        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
+        protected override string NewLangPickup(string langid = null)
+        {
+            string desc = "";
+            if (procRate > 0f) desc += $"Randomly freeze enemies";
+            else desc += $"Slow enemies";
+            desc += " for {duration:N0} seconds.";
+            return desc;
+        }
+        protected override string NewLangDesc(string langid = null)
+        {
+            string desc = "Summon a snowstorm that";
+            if (procRate > 0f) desc += $"<style=cIsUtility>freezes</style> monsters at a <style=cIsUtility>{Pct(procRate, 1, 1)} chance ";
+            else desc += $"<style=cIsUtility>slows</style> monsters <style=cIsUtility>";
+            desc += $"over {duration:N0} seconds</style>.";
+            return desc;
+        }
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public Snowglobe() {
@@ -88,24 +102,6 @@ namespace ThinkInvisible.ClassicItems {
             }
             NetworkServer.Spawn(ctrlInst);
             return true;
-        }
-
-        private string FormatNewLangDesc()
-        {
-            string desc = "Summon a snowstorm that";
-            if (procRate > 0f) desc += $"<style=cIsUtility>freezes</style> monsters at a <style=cIsUtility>{Pct(procRate, 1, 1)} chance ";
-            else desc += $"<style=cIsUtility>slows</style> monsters <style=cIsUtility>";
-            desc += $"over {duration:N0} seconds</style>.";
-            return desc;
-        }
-
-        private string FormatNewLangPickup()
-        {
-            string desc = "";
-            if (procRate > 0f) desc += $"Randomly freeze enemies";
-            else desc += $"Slow enemies";
-            desc += " for {duration:N0} seconds.";
-            return desc;
         }
     }
 

--- a/Items/Eqp/Snowglobe.cs
+++ b/Items/Eqp/Snowglobe.cs
@@ -31,8 +31,8 @@ namespace ThinkInvisible.ClassicItems {
 
         private GameObject snowglobeControllerPrefab;
         protected override string NewLangName(string langid = null) => displayName;
-        protected override string NewLangPickup(string langid = null) => "Randomly freeze enemies for " + duration.ToString("N0") + " seconds.";
-        protected override string NewLangDesc(string langid = null) => "Summon a snowstorm that <style=cIsUtility>freezes</style> monsters at a <style=cIsUtility>" + Pct(procRate,1,1) + " chance over " + duration.ToString("N0") + " seconds</style>.";
+        protected override string NewLangPickup(string langid = null) => FormatNewLangPickup();
+        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public Snowglobe() {
@@ -88,6 +88,25 @@ namespace ThinkInvisible.ClassicItems {
             }
             NetworkServer.Spawn(ctrlInst);
             return true;
+        }
+
+        private string FormatNewLangDesc()
+        {
+            string desc = "";
+            desc += "Summon a snowstorm that";
+            if (procRate > 0f) desc += $"<style=cIsUtility>freezes</style> monsters at a <style=cIsUtility>{Pct(procRate, 1, 1)} chance ";
+            else desc += $"<style=cIsUtility>slows</style> monsters <style=cIsUtility>";
+            desc += $"over {duration:N0} seconds</style>.";
+            return desc;
+        }
+
+        private string FormatNewLangPickup()
+        {
+            string desc = "";
+            if (procRate > 0f) desc += $"Randomly freeze enemies";
+            else desc += $"Slow enemies";
+            desc += " for {duration:N0} seconds.";
+            return desc;
         }
     }
 

--- a/Items/Eqp/Snowglobe.cs
+++ b/Items/Eqp/Snowglobe.cs
@@ -92,8 +92,7 @@ namespace ThinkInvisible.ClassicItems {
 
         private string FormatNewLangDesc()
         {
-            string desc = "";
-            desc += "Summon a snowstorm that";
+            string desc = "Summon a snowstorm that";
             if (procRate > 0f) desc += $"<style=cIsUtility>freezes</style> monsters at a <style=cIsUtility>{Pct(procRate, 1, 1)} chance ";
             else desc += $"<style=cIsUtility>slows</style> monsters <style=cIsUtility>";
             desc += $"over {duration:N0} seconds</style>.";

--- a/Items/EqpLunar/Lantern.cs
+++ b/Items/EqpLunar/Lantern.cs
@@ -26,9 +26,9 @@ namespace ThinkInvisible.ClassicItems {
         private GameObject lanternWardPrefab;
 
 		public override bool eqpIsLunar{get;} = true;        
-        protected override string NewLangName(string langid = null) => displayName;        
-        protected override string NewLangPickup(string langid = null) => "Drop a lantern that fears and damages enemies for " + duration.ToString("N0") + " seconds.";        
-        protected override string NewLangDesc(string langid = null) => "Sets a " + range.ToString("N0") + "-meter, " + duration.ToString("N0") + "-second AoE which <style=cIsUtility>fears enemies</style> and deals <style=cIsDamage>" + Pct(damage) + " damage per second</style>. <style=cIsUtility>Feared enemies will run out of melee</style>, <style=cDeath>but that won't stop them from shooting you.</style>";        
+        protected override string NewLangName(string langid = null) => displayName;
+		protected override string NewLangPickup(string langid = null) => FormatNewLangPickup();
+		protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
 		public Lantern() {
@@ -66,7 +66,23 @@ namespace ThinkInvisible.ClassicItems {
             }
             return true;
         }
-    }
+
+		private string FormatNewLangPickup()
+        {
+			string desc = "Drop a lantern that fears";
+			if (damage > 0f) desc += " and damages";
+			desc += $" enemies for {duration:N0} seconds.";
+			return desc;
+        }
+
+		private string FormatNewLangDesc()
+		{
+			string desc = $"Sets a {range:N0}m, {duration:N0}-second AoE which <style=cIsUtility>fears enemies</style>";
+			if (damage > 0f) desc += $" and deals <style=cIsDamage>{Pct(damage)} damage per second</style>";
+			desc += ". <style = cIsUtility> Feared enemies will run away</style>, <style=cDeath>but that won't stop them from performing ranged attacks.</style>";
+			return desc;
+		}
+	}
 
     [RequireComponent(typeof(TeamFilter))]
 	public class LanternWard : NetworkBehaviour {

--- a/Items/EqpLunar/Lantern.cs
+++ b/Items/EqpLunar/Lantern.cs
@@ -27,8 +27,20 @@ namespace ThinkInvisible.ClassicItems {
 
 		public override bool eqpIsLunar{get;} = true;        
         protected override string NewLangName(string langid = null) => displayName;
-		protected override string NewLangPickup(string langid = null) => FormatNewLangPickup();
-		protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
+		protected override string NewLangPickup(string langid = null)
+        {
+			string desc = "Drop a lantern that fears";
+			if (damage > 0f) desc += " and damages";
+			desc += $" enemies for {duration:N0} seconds.";
+			return desc;
+		}
+		protected override string NewLangDesc(string langid = null)
+        {
+			string desc = $"Sets a {range:N0}m, {duration:N0}-second AoE which <style=cIsUtility>fears enemies</style>";
+			if (damage > 0f) desc += $" and deals <style=cIsDamage>{Pct(damage)} damage per second</style>";
+			desc += ". <style=cIsUtility>Feared enemies will run away</style>, <style=cDeath>but that won't stop them from performing ranged attacks</style>.";
+			return desc;
+		}
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
 		public Lantern() {
@@ -66,22 +78,6 @@ namespace ThinkInvisible.ClassicItems {
             }
             return true;
         }
-
-		private string FormatNewLangPickup()
-        {
-			string desc = "Drop a lantern that fears";
-			if (damage > 0f) desc += " and damages";
-			desc += $" enemies for {duration:N0} seconds.";
-			return desc;
-        }
-
-		private string FormatNewLangDesc()
-		{
-			string desc = $"Sets a {range:N0}m, {duration:N0}-second AoE which <style=cIsUtility>fears enemies</style>";
-			if (damage > 0f) desc += $" and deals <style=cIsDamage>{Pct(damage)} damage per second</style>";
-			desc += ". <style=cIsUtility>Feared enemies will run away</style>, <style=cDeath>but that won't stop them from performing ranged attacks</style>.";
-			return desc;
-		}
 	}
 
     [RequireComponent(typeof(TeamFilter))]

--- a/Items/EqpLunar/Lantern.cs
+++ b/Items/EqpLunar/Lantern.cs
@@ -38,7 +38,7 @@ namespace ThinkInvisible.ClassicItems {
         {
 			string desc = $"Sets a {range:N0}-meter, {duration:N0}-second AoE which <style=cIsUtility>fears enemies</style>";
 			if (damage > 0f) desc += $" and deals <style=cIsDamage>{Pct(damage)} damage per second</style>";
-			desc += ". <style=cIsUtility>Feared enemies will run away</style>, <style=cDeath>but that won't stop them from performing ranged attacks</style>.";
+			desc += ". <style=cIsUtility>Feared enemies will run out of melee</style>, <style=cDeath>but that won't stop them from performing ranged attacks</style>.";
 			return desc;
 		}
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";

--- a/Items/EqpLunar/Lantern.cs
+++ b/Items/EqpLunar/Lantern.cs
@@ -79,7 +79,7 @@ namespace ThinkInvisible.ClassicItems {
 		{
 			string desc = $"Sets a {range:N0}m, {duration:N0}-second AoE which <style=cIsUtility>fears enemies</style>";
 			if (damage > 0f) desc += $" and deals <style=cIsDamage>{Pct(damage)} damage per second</style>";
-			desc += ". <style = cIsUtility> Feared enemies will run away</style>, <style=cDeath>but that won't stop them from performing ranged attacks.</style>";
+			desc += ". <style=cIsUtility>Feared enemies will run away</style>, <style=cDeath>but that won't stop them from performing ranged attacks</style>.";
 			return desc;
 		}
 	}

--- a/Items/EqpLunar/Lantern.cs
+++ b/Items/EqpLunar/Lantern.cs
@@ -36,7 +36,7 @@ namespace ThinkInvisible.ClassicItems {
 		}
 		protected override string NewLangDesc(string langid = null)
         {
-			string desc = $"Sets a {range:N0}m, {duration:N0}-second AoE which <style=cIsUtility>fears enemies</style>";
+			string desc = $"Sets a {range:N0}-meter, {duration:N0}-second AoE which <style=cIsUtility>fears enemies</style>";
 			if (damage > 0f) desc += $" and deals <style=cIsDamage>{Pct(damage)} damage per second</style>";
 			desc += ". <style=cIsUtility>Feared enemies will run away</style>, <style=cDeath>but that won't stop them from performing ranged attacks</style>.";
 			return desc;

--- a/Items/EqpLunar/LostDoll.cs
+++ b/Items/EqpLunar/LostDoll.cs
@@ -20,8 +20,23 @@ namespace ThinkInvisible.ClassicItems {
         
 		public override bool eqpIsLunar{get;} = true;
         protected override string NewLangName(string langid = null) => displayName;
-        protected override string NewLangPickup(string langid = null) => FormatNewLangPickup();
-        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
+        protected override string NewLangPickup(string langid = null)
+        {
+            string desc = "";
+            if (damageTaken > 0f) desc += "Harm yourself to";
+            else desc += "Use to";
+            desc += " damage an enemy.";
+            return desc;
+        }
+        protected override string NewLangDesc(string langid = null)
+        {
+            string desc = "";
+            if (damageTaken > 0f) desc += $"Sacrifice <style=cIsDamage>{Pct(damageTaken)}</style> of your <style=cIsDamage>current health</style>";
+            else desc += "Use";
+            desc += $" to damage the nearest enemy for <style=cIsDamage>{Pct(damageGiven)}</style> of your <style=cIsDamage>maximum health</style>.";
+
+            return desc;
+        }
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public LostDoll() { }
@@ -96,25 +111,6 @@ namespace ThinkInvisible.ClassicItems {
                 }
             }
             return didHit;
-        }
-
-        private string FormatNewLangPickup()
-        {
-            string desc = "";
-            if (damageTaken > 0f) desc += "Harm yourself to";
-            else desc += "Use to";
-            desc += " damage an enemy.";
-            return desc;
-        }
-
-        private string FormatNewLangDesc()
-        {
-            string desc = "";
-            if (damageTaken > 0f) desc += $"Sacrifice <style=cIsDamage>{Pct(damageTaken)}</style> of your <style=cIsDamage>current health</style>";
-            else desc += "Use";
-            desc += $" to damage the nearest enemy for <style=cIsDamage>{Pct(damageGiven)}</style> of your <style=cIsDamage>maximum health</style>.";
-
-            return desc;
         }
     }
 

--- a/Items/EqpLunar/LostDoll.cs
+++ b/Items/EqpLunar/LostDoll.cs
@@ -11,17 +11,17 @@ namespace ThinkInvisible.ClassicItems {
         public override string displayName => "Lost Doll";
 
         [AutoUpdateEventInfo(AutoUpdateEventFlags.InvalidateDescToken)]
-        [AutoItemConfig("Fraction of CURRENT health to take from the user when Lost Doll is activated.", AutoItemConfigFlags.None, 0f, 1f)]
+        [AutoItemConfig("Fraction of the user's CURRENT health to take from the user when Lost Doll is activated.", AutoItemConfigFlags.None, 0f, 1f)]
         public float damageTaken {get;private set;} = 0.25f;
 
         [AutoUpdateEventInfo(AutoUpdateEventFlags.InvalidateDescToken)]
-        [AutoItemConfig("Fraction of MAXIMUM health to deal in damage to the closest enemy when Lost Doll is activated.", AutoItemConfigFlags.None, 0f, float.MaxValue)]
+        [AutoItemConfig("Fraction of the user's MAXIMUM health to deal in damage to the closest enemy when Lost Doll is activated.", AutoItemConfigFlags.None, 0f, float.MaxValue)]
         public float damageGiven {get;private set;} = 5f;
         
 		public override bool eqpIsLunar{get;} = true;
         protected override string NewLangName(string langid = null) => displayName;
-        protected override string NewLangPickup(string langid = null) => "Harm yourself to instantly kill an enemy.";
-        protected override string NewLangDesc(string langid = null) => "Sacrifices <style=cIsDamage>" + Pct(damageTaken) + "</style> of your <style=cIsDamage>current health</style> to damage the nearest enemy for <style=cIsDamage>" + Pct(damageGiven) + "</style> of your <style=cIsDamage>maximum health</style>.";
+        protected override string NewLangPickup(string langid = null) => FormatNewLangPickup();
+        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public LostDoll() { }
@@ -96,6 +96,25 @@ namespace ThinkInvisible.ClassicItems {
                 }
             }
             return didHit;
+        }
+
+        private string FormatNewLangPickup()
+        {
+            string desc = "";
+            if (damageTaken > 0f) desc += "Harm yourself to";
+            else desc += "Use to";
+            desc += " damage an enemy.";
+            return desc;
+        }
+
+        private string FormatNewLangDesc()
+        {
+            string desc = "";
+            if (damageTaken > 0f) desc += $"Sacrifice <style=cIsDamage>{Pct(damageTaken)}</style> of your <style=cIsDamage>current health</style>";
+            else desc += "Use";
+            desc += $" to damage the nearest enemy for <style=cIsDamage>{Pct(damageGiven)}</style> of your <style=cIsDamage>maximum health</style>.";
+
+            return desc;
         }
     }
 

--- a/Items/T1/BarbedWire.cs
+++ b/Items/T1/BarbedWire.cs
@@ -38,8 +38,8 @@ namespace ThinkInvisible.ClassicItems {
 
 		internal static GameObject barbedWardPrefab;        
         protected override string NewLangName(string langid = null) => displayName;        
-        protected override string NewLangPickup(string langid = null) => "Hurt nearby enemies.";        
-        protected override string NewLangDesc(string langid = null) => "Deal <style=cIsDamage>" + Pct(baseDmg) + "</style> <style=cStack>(+" + Pct(stackDmg) + " per stack)</style> <style=cIsDamage>damage/sec</style> to enemies within <style=cIsDamage>" + baseRadius.ToString("N1") + " m</style> <style=cStack>(+ " + stackRadius.ToString("N2") + " per stack)</style>";        
+        protected override string NewLangPickup(string langid = null) => "Hurt nearby enemies.";
+		protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
 		public BarbedWire() {
@@ -126,6 +126,16 @@ namespace ThinkInvisible.ClassicItems {
 				cpt.GetComponent<BarbedWard>().netDamage = (baseDmg + (icnt-1) * stackDmg) * idmg;
 			}
 		}
+
+		private string FormatNewLangDesc()
+        {
+			string desc = $"Deal <style=cIsDamage>{Pct(baseDmg)}</style>";
+			if (stackDmg > 0f) desc += $" <style=cStack>(+{Pct(stackDmg)} per stack)</style>";
+			desc += $" <style=cIsDamage>damage/sec</style> to enemies within <style=cIsDamage>{baseRadius:N1}m</style>";
+			if (stackRadius > 0f) desc += $" <style=cStack>(+{stackRadius:N2} per stack)</style>";
+			desc += ".";
+			return desc;
+        }
     }
 
 	public class BarbedWireOrb : LightningOrb {

--- a/Items/T1/BarbedWire.cs
+++ b/Items/T1/BarbedWire.cs
@@ -43,7 +43,7 @@ namespace ThinkInvisible.ClassicItems {
         {
 			string desc = $"Deal <style=cIsDamage>{Pct(baseDmg)}</style>";
 			if (stackDmg > 0f) desc += $" <style=cStack>(+{Pct(stackDmg)} per stack)</style>";
-			desc += $" <style=cIsDamage>damage/sec</style> to enemies within <style=cIsDamage>{baseRadius:N1}m</style>";
+			desc += $" <style=cIsDamage>damage/sec</style> to enemies within <style=cIsDamage>{baseRadius:N1} meters</style>";
 			if (stackRadius > 0f) desc += $" <style=cStack>(+{stackRadius:N2} per stack)</style>";
 			desc += ".";
 			return desc;

--- a/Items/T1/BarbedWire.cs
+++ b/Items/T1/BarbedWire.cs
@@ -39,7 +39,15 @@ namespace ThinkInvisible.ClassicItems {
 		internal static GameObject barbedWardPrefab;        
         protected override string NewLangName(string langid = null) => displayName;        
         protected override string NewLangPickup(string langid = null) => "Hurt nearby enemies.";
-		protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
+		protected override string NewLangDesc(string langid = null)
+        {
+			string desc = $"Deal <style=cIsDamage>{Pct(baseDmg)}</style>";
+			if (stackDmg > 0f) desc += $" <style=cStack>(+{Pct(stackDmg)} per stack)</style>";
+			desc += $" <style=cIsDamage>damage/sec</style> to enemies within <style=cIsDamage>{baseRadius:N1}m</style>";
+			if (stackRadius > 0f) desc += $" <style=cStack>(+{stackRadius:N2} per stack)</style>";
+			desc += ".";
+			return desc;
+		}
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
 		public BarbedWire() {
@@ -126,16 +134,6 @@ namespace ThinkInvisible.ClassicItems {
 				cpt.GetComponent<BarbedWard>().netDamage = (baseDmg + (icnt-1) * stackDmg) * idmg;
 			}
 		}
-
-		private string FormatNewLangDesc()
-        {
-			string desc = $"Deal <style=cIsDamage>{Pct(baseDmg)}</style>";
-			if (stackDmg > 0f) desc += $" <style=cStack>(+{Pct(stackDmg)} per stack)</style>";
-			desc += $" <style=cIsDamage>damage/sec</style> to enemies within <style=cIsDamage>{baseRadius:N1}m</style>";
-			if (stackRadius > 0f) desc += $" <style=cStack>(+{stackRadius:N2} per stack)</style>";
-			desc += ".";
-			return desc;
-        }
     }
 
 	public class BarbedWireOrb : LightningOrb {

--- a/Items/T1/BitterRoot.cs
+++ b/Items/T1/BitterRoot.cs
@@ -20,8 +20,8 @@ namespace ThinkInvisible.ClassicItems {
         public float healthCap {get; private set;} = 3f;
 
         protected override string NewLangName(string langid = null) => displayName;        
-        protected override string NewLangPickup(string langid = null) => "Gain " + Pct(healthMult) + " max hp.";
-        protected override string NewLangDesc(string langid = null) => "Increases <style=cIsHealing>health</style> by <style=cIsHealing>" + Pct(healthMult) + "</style> <style=cStack>(+" +Pct(healthMult)+ " per stack, linear)</style>, up to a <style=cIsHealing>maximum</style> of <style=cIsHealing>+"+Pct(healthCap)+"</style>.";        
+        protected override string NewLangPickup(string langid = null) => "Gain " + Pct(healthMult) + " max health.";
+        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public BitterRoot() {
@@ -45,6 +45,14 @@ namespace ThinkInvisible.ClassicItems {
 
         private void Evt_TILER2GetStatCoefficients(CharacterBody sender, StatHookEventArgs args) {
             args.healthMultAdd += Math.Min(GetCount(sender) * healthMult, healthCap);
+        }
+
+        private string FormatNewLangDesc()
+        {
+            string desc = $"Increases <style=cIsHealing>health</style> by <style=cIsHealing>{Pct(healthMult)}</style>";
+            if (healthMult > 0f) desc += $" <style=cStack>(+{Pct(healthMult)} per stack, linear)</style>";
+            desc += $", up to a <style=cIsHealing>maximum</style> of <style=cIsHealing>+{Pct(healthCap)}</style>.";
+            return desc;
         }
     }
 }

--- a/Items/T1/BitterRoot.cs
+++ b/Items/T1/BitterRoot.cs
@@ -21,7 +21,13 @@ namespace ThinkInvisible.ClassicItems {
 
         protected override string NewLangName(string langid = null) => displayName;        
         protected override string NewLangPickup(string langid = null) => "Gain " + Pct(healthMult) + " max health.";
-        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
+        protected override string NewLangDesc(string langid = null)
+        {
+            string desc = $"Increases <style=cIsHealing>health</style> by <style=cIsHealing>{Pct(healthMult)}</style>";
+            if (healthMult > 0f) desc += $" <style=cStack>(+{Pct(healthMult)} per stack, linear)</style>";
+            desc += $", up to a <style=cIsHealing>maximum</style> of <style=cIsHealing>+{Pct(healthCap)}</style>.";
+            return desc;
+        }
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public BitterRoot() {
@@ -45,14 +51,6 @@ namespace ThinkInvisible.ClassicItems {
 
         private void Evt_TILER2GetStatCoefficients(CharacterBody sender, StatHookEventArgs args) {
             args.healthMultAdd += Math.Min(GetCount(sender) * healthMult, healthCap);
-        }
-
-        private string FormatNewLangDesc()
-        {
-            string desc = $"Increases <style=cIsHealing>health</style> by <style=cIsHealing>{Pct(healthMult)}</style>";
-            if (healthMult > 0f) desc += $" <style=cStack>(+{Pct(healthMult)} per stack, linear)</style>";
-            desc += $", up to a <style=cIsHealing>maximum</style> of <style=cIsHealing>+{Pct(healthCap)}</style>.";
-            return desc;
         }
     }
 }

--- a/Items/T1/BitterRoot.cs
+++ b/Items/T1/BitterRoot.cs
@@ -20,10 +20,10 @@ namespace ThinkInvisible.ClassicItems {
         public float healthCap {get; private set;} = 3f;
 
         protected override string NewLangName(string langid = null) => displayName;        
-        protected override string NewLangPickup(string langid = null) => "Gain " + Pct(healthMult) + " max health.";
+        protected override string NewLangPickup(string langid = null) => "Gain " + Pct(healthMult) + " HP.";
         protected override string NewLangDesc(string langid = null)
         {
-            string desc = $"Increases <style=cIsHealing>health</style> by <style=cIsHealing>{Pct(healthMult)}</style>";
+            string desc = $"Increases <style=cIsHealing>HP</style> by <style=cIsHealing>{Pct(healthMult)}</style>";
             if (healthMult > 0f) desc += $" <style=cStack>(+{Pct(healthMult)} per stack, linear)</style>";
             desc += $", up to a <style=cIsHealing>maximum</style> of <style=cIsHealing>+{Pct(healthCap)}</style>.";
             return desc;

--- a/Items/T1/FireShield.cs
+++ b/Items/T1/FireShield.cs
@@ -31,7 +31,7 @@ namespace ThinkInvisible.ClassicItems {
 
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Retaliate on taking heavy damage.";
-        protected override string NewLangDesc(string langid = null) => "<style=cDeath>When hit for more than " + Pct(healthThreshold) + " max health</style>, <style=cIsDamage>explode</style> for up to <style=cIsDamage>" + Pct(baseDmg) + "</style> <style=cStack>(+" + Pct(stackDmg) + " per stack)</style> damage to enemies within <style=cIsDamage>" + baseRadius.ToString("N0") + " m</style>.";
+        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public FireShield() {
@@ -89,6 +89,14 @@ namespace ThinkInvisible.ClassicItems {
 				damageType = DamageType.AOE,
 				procCoefficient = 1.0f
 			}.Fire();
+        }
+
+        private string FormatNewLangDesc()
+        {
+            string desc = $"<style=cDeath>When hit for more than {Pct(healthThreshold)} max health</style>, <style=cIsDamage>explode</style> for up to <style=cIsDamage>{Pct(baseDmg)}</style>";
+            if (stackDmg > 0f) desc += $"<style=cStack>(+{Pct(stackDmg)} per stack)</style>";
+            desc += $" damage to enemies within <style=cIsDamage>{baseRadius:N0}m</style>.";
+            return desc;
         }
 	}
 }

--- a/Items/T1/FireShield.cs
+++ b/Items/T1/FireShield.cs
@@ -31,7 +31,15 @@ namespace ThinkInvisible.ClassicItems {
 
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Retaliate on taking heavy damage.";
-        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
+        protected override string NewLangDesc(string langid = null)
+        {
+            string desc = $"<style=cDeath>When hit";
+            if (healthThreshold > 0f) desc += " for more than {Pct(healthThreshold)} of max health</style>";
+            desc += ", <style=cIsDamage>explode</style> for up to <style=cIsDamage>{Pct(baseDmg)}</style>";
+            if (stackDmg > 0f) desc += $"<style=cStack>(+{Pct(stackDmg)} per stack)</style>";
+            desc += $" damage to enemies within <style=cIsDamage>{baseRadius:N0}m</style>.";
+            return desc;
+        }
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public FireShield() {
@@ -89,16 +97,6 @@ namespace ThinkInvisible.ClassicItems {
 				damageType = DamageType.AOE,
 				procCoefficient = 1.0f
 			}.Fire();
-        }
-
-        private string FormatNewLangDesc()
-        {
-            string desc = $"<style=cDeath>When hit";
-            if (healthThreshold > 0f) desc += " for more than {Pct(healthThreshold)} of max health</style>";
-            desc += ", <style=cIsDamage>explode</style> for up to <style=cIsDamage>{Pct(baseDmg)}</style>";
-            if (stackDmg > 0f) desc += $"<style=cStack>(+{Pct(stackDmg)} per stack)</style>";
-            desc += $" damage to enemies within <style=cIsDamage>{baseRadius:N0}m</style>.";
-            return desc;
         }
 	}
 }

--- a/Items/T1/FireShield.cs
+++ b/Items/T1/FireShield.cs
@@ -93,7 +93,9 @@ namespace ThinkInvisible.ClassicItems {
 
         private string FormatNewLangDesc()
         {
-            string desc = $"<style=cDeath>When hit for more than {Pct(healthThreshold)} max health</style>, <style=cIsDamage>explode</style> for up to <style=cIsDamage>{Pct(baseDmg)}</style>";
+            string desc = $"<style=cDeath>When hit";
+            if (healthThreshold > 0f) desc += " for more than {Pct(healthThreshold)} of max health</style>";
+            desc += ", <style=cIsDamage>explode</style> for up to <style=cIsDamage>{Pct(baseDmg)}</style>";
             if (stackDmg > 0f) desc += $"<style=cStack>(+{Pct(stackDmg)} per stack)</style>";
             desc += $" damage to enemies within <style=cIsDamage>{baseRadius:N0}m</style>.";
             return desc;

--- a/Items/T1/FireShield.cs
+++ b/Items/T1/FireShield.cs
@@ -37,7 +37,7 @@ namespace ThinkInvisible.ClassicItems {
             if (healthThreshold > 0f) desc += " for more than {Pct(healthThreshold)} of max health</style>";
             desc += ", <style=cIsDamage>explode</style> for up to <style=cIsDamage>{Pct(baseDmg)}</style>";
             if (stackDmg > 0f) desc += $"<style=cStack>(+{Pct(stackDmg)} per stack)</style>";
-            desc += $" damage to enemies within <style=cIsDamage>{baseRadius:N0}m</style>.";
+            desc += $" damage to enemies within <style=cIsDamage>{baseRadius:N0} meters</style>.";
             return desc;
         }
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";

--- a/Items/T1/Headstompers.cs
+++ b/Items/T1/Headstompers.cs
@@ -31,9 +31,9 @@ namespace ThinkInvisible.ClassicItems {
         protected override string NewLangPickup(string langid = null) => "Hurt enemies by falling.";
         protected override string NewLangDesc(string langid = null)
         {
-            string desc = $"Hitting the ground faster than <style=cIsDamage>{velThreshold:N1}m/s</style> vertically causes a <style=cIsDamage>10m</style> radius <style=cIsDamage>kinetic explosion</style>, dealing up to <style=cIsDamage>{Pct(baseDamage)} base damage</style>";
+            string desc = $"Hitting the ground faster than <style=cIsDamage>{velThreshold:N1} meters per second</style> vertically causes a <style=cIsDamage>10-meter</style> radius <style=cIsDamage>kinetic explosion</style>, dealing up to <style=cIsDamage>{Pct(baseDamage)} base damage</style>";
             if (stackDamage > 0f) desc += $"<style=cStack>(+{Pct(stackDamage)} per stack, linear)</style>";
-            desc += $". <style=cIsDamage>Max damage</style> requires <style=cIsDamage>{(velMax + velThreshold):N1}m/s falling speed</style>.";
+            desc += $". <style=cIsDamage>Max damage</style> requires <style=cIsDamage>{(velMax + velThreshold):N1} meters per second falling speed</style>.";
             return desc;
         }
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";

--- a/Items/T1/Headstompers.cs
+++ b/Items/T1/Headstompers.cs
@@ -29,7 +29,7 @@ namespace ThinkInvisible.ClassicItems {
         public float velMax {get;private set;} = 40f;
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Hurt enemies by falling.";
-        protected override string NewLangDesc(string langid = null) => "Hitting the ground faster than <style=cIsDamage>" + velThreshold.ToString("N1") + " m/s</style> (vertical component only) causes a <style=cIsDamage>10 m</style> radius <style=cIsDamage>kinetic explosion</style>, dealing up to <style=cIsDamage>" + Pct(baseDamage) + " base damage</style> <style=cStack>(+" + Pct(stackDamage) + " per stack, linear)</style>. <style=cIsDamage>Max damage</style> requires <style=cIsDamage>" + (velMax+velThreshold).ToString("N1") + " m/s falling speed</style>.";
+        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public Headstompers() {
@@ -78,6 +78,14 @@ namespace ThinkInvisible.ClassicItems {
                 };
 				EffectManager.SpawnEffect(Resources.Load<GameObject>("Prefabs/Effects/ImpactEffects/BootShockwave"), effectData, true);
             }
+        }
+
+        private string FormatNewLangDesc()
+        {
+            string desc = $"Hitting the ground faster than <style=cIsDamage>{velThreshold:N1}m/s</style> vertically causes a <style=cIsDamage>10m</style> radius <style=cIsDamage>kinetic explosion</style>, dealing up to <style=cIsDamage>{Pct(baseDamage)} base damage</style>";
+            if (stackDamage > 0f) desc += $"<style=cStack>(+{Pct(stackDamage)} per stack, linear)</style>";
+            desc += $". <style=cIsDamage>Max damage</style> requires <style=cIsDamage>{(velMax + velThreshold):N1}m/s falling speed</style>.";
+            return desc;
         }
     }
 }

--- a/Items/T1/Headstompers.cs
+++ b/Items/T1/Headstompers.cs
@@ -29,7 +29,13 @@ namespace ThinkInvisible.ClassicItems {
         public float velMax {get;private set;} = 40f;
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Hurt enemies by falling.";
-        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
+        protected override string NewLangDesc(string langid = null)
+        {
+            string desc = $"Hitting the ground faster than <style=cIsDamage>{velThreshold:N1}m/s</style> vertically causes a <style=cIsDamage>10m</style> radius <style=cIsDamage>kinetic explosion</style>, dealing up to <style=cIsDamage>{Pct(baseDamage)} base damage</style>";
+            if (stackDamage > 0f) desc += $"<style=cStack>(+{Pct(stackDamage)} per stack, linear)</style>";
+            desc += $". <style=cIsDamage>Max damage</style> requires <style=cIsDamage>{(velMax + velThreshold):N1}m/s falling speed</style>.";
+            return desc;
+        }
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public Headstompers() {
@@ -78,14 +84,6 @@ namespace ThinkInvisible.ClassicItems {
                 };
 				EffectManager.SpawnEffect(Resources.Load<GameObject>("Prefabs/Effects/ImpactEffects/BootShockwave"), effectData, true);
             }
-        }
-
-        private string FormatNewLangDesc()
-        {
-            string desc = $"Hitting the ground faster than <style=cIsDamage>{velThreshold:N1}m/s</style> vertically causes a <style=cIsDamage>10m</style> radius <style=cIsDamage>kinetic explosion</style>, dealing up to <style=cIsDamage>{Pct(baseDamage)} base damage</style>";
-            if (stackDamage > 0f) desc += $"<style=cStack>(+{Pct(stackDamage)} per stack, linear)</style>";
-            desc += $". <style=cIsDamage>Max damage</style> requires <style=cIsDamage>{(velMax + velThreshold):N1}m/s falling speed</style>.";
-            return desc;
         }
     }
 }

--- a/Items/T1/Spikestrip.cs
+++ b/Items/T1/Spikestrip.cs
@@ -28,7 +28,7 @@ namespace ThinkInvisible.ClassicItems {
 		internal static GameObject spikeWardPrefab;
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Drop spikestrips on being hit, slowing enemies.";
-        protected override string NewLangDesc(string langid = null) => "<style=cIsDamage>When hit</style>, drop a <style=cIsUtility>" + baseRadius.ToString("N0") + " m AoE</style> which <style=cIsUtility>slows enemies by 50%</style> and lasts <style=cIsUtility>" + baseDuration.ToString("N1") + " s</style> <style=cStack>(+" + stackDuration.ToString("N1") + " s per stack)</style>.";
+        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public Spikestrip() {
@@ -82,6 +82,14 @@ namespace ThinkInvisible.ClassicItems {
 			cpt.GetComponent<TeamFilter>().teamIndex = self.body.teamComponent.teamIndex;
             cpt.AddComponent<DestroyOnTimer>().duration = baseDuration + stackDuration * (icnt - 1);
             NetworkServer.Spawn(cpt);
+        }
+
+        private string FormatNewLangDesc()
+        {
+            string desc = $"<style=cIsDamage>When hit</style>, drop a <style=cIsUtility>{baseRadius:N0}m AoE</style> which <style=cIsUtility>slows enemies by 50%</style> and lasts <style=cIsUtility>{baseDuration:N1}s</style>";
+            if (stackDuration > 0f) desc += $"<style=cStack>(+{stackDuration:N1}s per stack)</style>";
+            desc += ".";
+            return desc;
         }
 	}
 }

--- a/Items/T1/Spikestrip.cs
+++ b/Items/T1/Spikestrip.cs
@@ -28,7 +28,13 @@ namespace ThinkInvisible.ClassicItems {
 		internal static GameObject spikeWardPrefab;
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Drop spikestrips on being hit, slowing enemies.";
-        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
+        protected override string NewLangDesc(string langid = null)
+        {
+            string desc = $"<style=cIsDamage>When hit</style>, drop a <style=cIsUtility>{baseRadius:N0}m AoE</style> which <style=cIsUtility>slows enemies by 50%</style> and lasts <style=cIsUtility>{baseDuration:N1}s</style>";
+            if (stackDuration > 0f) desc += $"<style=cStack>(+{stackDuration:N1}s per stack)</style>";
+            desc += ".";
+            return desc;
+        }
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public Spikestrip() {
@@ -82,14 +88,6 @@ namespace ThinkInvisible.ClassicItems {
 			cpt.GetComponent<TeamFilter>().teamIndex = self.body.teamComponent.teamIndex;
             cpt.AddComponent<DestroyOnTimer>().duration = baseDuration + stackDuration * (icnt - 1);
             NetworkServer.Spawn(cpt);
-        }
-
-        private string FormatNewLangDesc()
-        {
-            string desc = $"<style=cIsDamage>When hit</style>, drop a <style=cIsUtility>{baseRadius:N0}m AoE</style> which <style=cIsUtility>slows enemies by 50%</style> and lasts <style=cIsUtility>{baseDuration:N1}s</style>";
-            if (stackDuration > 0f) desc += $"<style=cStack>(+{stackDuration:N1}s per stack)</style>";
-            desc += ".";
-            return desc;
         }
 	}
 }

--- a/Items/T1/Spikestrip.cs
+++ b/Items/T1/Spikestrip.cs
@@ -30,8 +30,8 @@ namespace ThinkInvisible.ClassicItems {
         protected override string NewLangPickup(string langid = null) => "Drop spikestrips on being hit, slowing enemies.";
         protected override string NewLangDesc(string langid = null)
         {
-            string desc = $"<style=cIsDamage>When hit</style>, drop a <style=cIsUtility>{baseRadius:N0}m AoE</style> which <style=cIsUtility>slows enemies by 50%</style> and lasts <style=cIsUtility>{baseDuration:N1}s</style>";
-            if (stackDuration > 0f) desc += $"<style=cStack>(+{stackDuration:N1}s per stack)</style>";
+            string desc = $"<style=cIsDamage>When hit</style>, drop a <style=cIsUtility>{baseRadius:N0}-meter AoE</style> which <style=cIsUtility>slows enemies by 50%</style> and lasts <style=cIsUtility>{baseDuration:N1} seconds</style>";
+            if (stackDuration > 0f) desc += $"<style=cStack>(+{stackDuration:N1} per stack)</style>";
             desc += ".";
             return desc;
         }

--- a/Items/T1/Taser.cs
+++ b/Items/T1/Taser.cs
@@ -24,7 +24,7 @@ namespace ThinkInvisible.ClassicItems {
 
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Chance to snare on hit.";
-        protected override string NewLangDesc(string langid = null) => "<style=cIsUtility>" + Pct(procChance,0,1) + "</style> chance to <style=cIsUtility>entangle</style> an enemy for <style=cIsUtility>" + procTime.ToString("N1") + " seconds</style> <style=cStack>(+ " + stackTime.ToString("N1") + " per stack)</style>.";
+        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public Taser() {
@@ -61,6 +61,14 @@ namespace ThinkInvisible.ClassicItems {
                     self.body.AddTimedBuff(BuffIndex.Entangle, procTime + (icnt-1) * stackTime);
                 }
             }
+        }
+
+        private string FormatNewLangDesc()
+        {
+            string desc = "<style=cIsUtility>" + Pct(procChance, 0, 1) + "</style> chance to <style=cIsUtility>entangle</style> an enemy for <style=cIsUtility>" + procTime.ToString("N1") + " seconds</style>";
+            if (stackTime > 0f) desc += $"<style=cStack>(+{stackTime:N1} seconds per stack)</style>";
+            desc += ".";
+            return desc;
         }
     }
 }

--- a/Items/T1/Taser.cs
+++ b/Items/T1/Taser.cs
@@ -24,7 +24,13 @@ namespace ThinkInvisible.ClassicItems {
 
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Chance to snare on hit.";
-        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
+        protected override string NewLangDesc(string langid = null)
+        {
+            string desc = "<style=cIsUtility>" + Pct(procChance, 0, 1) + "</style> chance to <style=cIsUtility>entangle</style> an enemy for <style=cIsUtility>" + procTime.ToString("N1") + " seconds</style>";
+            if (stackTime > 0f) desc += $"<style=cStack>(+{stackTime:N1} seconds per stack)</style>";
+            desc += ".";
+            return desc;
+        }
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public Taser() {
@@ -61,14 +67,6 @@ namespace ThinkInvisible.ClassicItems {
                     self.body.AddTimedBuff(BuffIndex.Entangle, procTime + (icnt-1) * stackTime);
                 }
             }
-        }
-
-        private string FormatNewLangDesc()
-        {
-            string desc = "<style=cIsUtility>" + Pct(procChance, 0, 1) + "</style> chance to <style=cIsUtility>entangle</style> an enemy for <style=cIsUtility>" + procTime.ToString("N1") + " seconds</style>";
-            if (stackTime > 0f) desc += $"<style=cStack>(+{stackTime:N1} seconds per stack)</style>";
-            desc += ".";
-            return desc;
         }
     }
 }

--- a/Items/T1/Taser.cs
+++ b/Items/T1/Taser.cs
@@ -27,7 +27,7 @@ namespace ThinkInvisible.ClassicItems {
         protected override string NewLangDesc(string langid = null)
         {
             string desc = "<style=cIsUtility>" + Pct(procChance, 0, 1) + "</style> chance to <style=cIsUtility>entangle</style> an enemy for <style=cIsUtility>" + procTime.ToString("N1") + " seconds</style>";
-            if (stackTime > 0f) desc += $"<style=cStack>(+{stackTime:N1} seconds per stack)</style>";
+            if (stackTime > 0f) desc += $"<style=cStack>(+{stackTime:N1} per stack)</style>";
             desc += ".";
             return desc;
         }

--- a/Items/T2/BoxingGloves.cs
+++ b/Items/T2/BoxingGloves.cs
@@ -25,7 +25,7 @@ namespace ThinkInvisible.ClassicItems {
 
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Hitting enemies have a " + Pct(procChance,0,1) + " chance to knock them back.";
-        protected override string NewLangDesc(string langid = null) => "<style=cIsUtility>" + Pct(procChance,0,1) + "</style> <style=cStack>(+"+Pct(procChance,0,1)+" per stack, mult.)</style> chance to <style=cIsUtility>knock back</style> an enemy <style=cIsDamage>based on attack damage</style>.";
+        protected override string NewLangDesc(string langid = null) => "<style=cIsUtility>" + Pct(procChance,0,1) + "</style> <style=cStack>(+"+Pct(procChance,0,1)+" per stack, multiplicative)</style> chance to <style=cIsUtility>knock back</style> an enemy <style=cIsDamage>based on attack damage</style>.";
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public BoxingGloves() {

--- a/Items/T2/Clover.cs
+++ b/Items/T2/Clover.cs
@@ -51,8 +51,8 @@ namespace ThinkInvisible.ClassicItems {
         public bool inclDeploys {get;private set;} = false;
 
         protected override string NewLangName(string langid = null) => displayName;        
-        protected override string NewLangPickup(string langid = null) => "Elite mobs have a chance to drop items.";        
-        protected override string NewLangDesc(string langid = null) => "Elites have a <style=cIsUtility>" + Pct(baseChance, 1, 1) + " chance</style> <style=cStack>(+" + Pct(stackChance, 1, 1) + " per stack COMBINED FOR ALL PLAYERS, up to " + Pct(capChance, 1, 1) + ")</style> to <style=cIsUtility>drop items</style> when <style=cIsDamage>killed</style>. <style=cStack>(Further stacks increase uncommon/rare chance up to " +Pct(capUnc,2,1) +" and "+Pct(capRare,3,1)+", respectively.)</style>";        
+        protected override string NewLangPickup(string langid = null) => "Elite mobs have a chance to drop items.";
+        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public Clover() {
@@ -146,6 +146,14 @@ namespace ThinkInvisible.ClassicItems {
                 }
                 SpawnItemFromBody(victimBody, tier, itemRng);
             }
+        }
+
+        private string FormatNewLangDesc()
+        {
+            string desc = "Elites have a <style=cIsUtility>" + Pct(baseChance, 1, 1) + " chance</style> <style=cStack>(";
+            if (stackChance > 0f) desc += $"+{Pct(stackChance, 1, 1)} per stack, ";
+            desc += "COMBINED FOR ALL PLAYERS, up to " + Pct(capChance, 1, 1) + ")</style> to <style=cIsUtility>drop items</style> when <style=cIsDamage>killed</style>. <style=cStack>(Further stacks increase uncommon/rare chance up to " + Pct(capUnc, 2, 1) + " and " + Pct(capRare, 3, 1) + ", respectively.)</style>";
+            return desc;
         }
     }
 }

--- a/Items/T2/Clover.cs
+++ b/Items/T2/Clover.cs
@@ -52,7 +52,13 @@ namespace ThinkInvisible.ClassicItems {
 
         protected override string NewLangName(string langid = null) => displayName;        
         protected override string NewLangPickup(string langid = null) => "Elite mobs have a chance to drop items.";
-        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
+        protected override string NewLangDesc(string langid = null)
+        {
+            string desc = "Elites have a <style=cIsUtility>" + Pct(baseChance, 1, 1) + " chance</style> <style=cStack>(";
+            if (stackChance > 0f) desc += $"+{Pct(stackChance, 1, 1)} per stack, ";
+            desc += "COMBINED FOR ALL PLAYERS, up to " + Pct(capChance, 1, 1) + ")</style> to <style=cIsUtility>drop items</style> when <style=cIsDamage>killed</style>. <style=cStack>(Further stacks increase uncommon/rare chance up to " + Pct(capUnc, 2, 1) + " and " + Pct(capRare, 3, 1) + ", respectively.)</style>";
+            return desc;
+        }
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public Clover() {
@@ -146,14 +152,6 @@ namespace ThinkInvisible.ClassicItems {
                 }
                 SpawnItemFromBody(victimBody, tier, itemRng);
             }
-        }
-
-        private string FormatNewLangDesc()
-        {
-            string desc = "Elites have a <style=cIsUtility>" + Pct(baseChance, 1, 1) + " chance</style> <style=cStack>(";
-            if (stackChance > 0f) desc += $"+{Pct(stackChance, 1, 1)} per stack, ";
-            desc += "COMBINED FOR ALL PLAYERS, up to " + Pct(capChance, 1, 1) + ")</style> to <style=cIsUtility>drop items</style> when <style=cIsDamage>killed</style>. <style=cStack>(Further stacks increase uncommon/rare chance up to " + Pct(capUnc, 2, 1) + " and " + Pct(capRare, 3, 1) + ", respectively.)</style>";
-            return desc;
         }
     }
 }

--- a/Items/T2/Imprint.cs
+++ b/Items/T2/Imprint.cs
@@ -37,7 +37,7 @@ namespace ThinkInvisible.ClassicItems {
 
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Hatch a strange creature who drops buffs periodically.";
-        protected override string NewLangDesc(string langid = null) => "Every <style=cIsUtility>" + baseCD.ToString("N0") + " seconds</style> <style=cStack>(-" + Pct(stackCDreduc) + " per stack, min. " + baseDuration.ToString("N0") + " s)</style>, gain <style=cIsHealing>+" + Pct(regenMod) + " health regen</style> OR <style=cIsUtility>+" + Pct(speedMod) + " move speed</style> OR <style=cIsDamage>+" + Pct(attackMod) + " attack speed</style> for <style=cIsUtility>" + baseDuration.ToString("N0") + " seconds</style>.";
+        protected override string NewLangDesc(string langid = null) => "Every <style=cIsUtility>" + baseCD.ToString("N0") + " seconds</style> <style=cStack>(-" + Pct(stackCDreduc) + " per stack, minimum of " + baseDuration.ToString("N0") + " seconds)</style>, gain <style=cIsHealing>+" + Pct(regenMod) + " health regen</style> OR <style=cIsUtility>+" + Pct(speedMod) + " move speed</style> OR <style=cIsDamage>+" + Pct(attackMod) + " attack speed</style> for <style=cIsUtility>" + baseDuration.ToString("N0") + " seconds</style>.";
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
         
         public BuffIndex attackBuff {get; private set;}

--- a/Items/T3/Embryo.cs
+++ b/Items/T3/Embryo.cs
@@ -110,7 +110,7 @@ namespace ThinkInvisible.ClassicItems {
         }
 
         protected override string NewLangName(string langid = null) => displayName;        
-        protected override string NewLangPickup(string langid = null) => "Equipment has a 30% chance to deal double the effect.";        
+        protected override string NewLangPickup(string langid = null) => $"Equipment has a {Pct(procChance, 0, 1)} chance to deal double the effect.";        
         protected override string NewLangDesc(string langid = null) => "Upon activating an equipment, adds a <style=cIsUtility>" + Pct(procChance, 0, 1) + "</style> <style=cStack>(+" + Pct(procChance, 0, 1) + " per stack)</style> chance to <style=cIsUtility>double its effects somehow</style>.";        
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 

--- a/Items/T3/HitList.cs
+++ b/Items/T3/HitList.cs
@@ -28,7 +28,7 @@ namespace ThinkInvisible.ClassicItems {
 
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Killing marked enemies permanently increases damage.";
-        protected override string NewLangDesc(string langid = null) => "Every <style=cIsUtility>" + cooldown.ToString("N0") + " seconds</style>, <style=cIsUtility>1</style> <style=cStack>(+1 per stack)</style> random enemy will be <style=cIsUtility>marked</style> for the same duration. Killing <style=cIsUtility>marked</style> enemies gives you <style=cIsDamage>+" + procDamage.ToString("N1") + " permanent base damage</style> <style=cStack>(max. " + maxDamage.ToString("N1") + ")</style>.";
+        protected override string NewLangDesc(string langid = null) => "Every <style=cIsUtility>" + cooldown.ToString("N0") + " seconds</style>, <style=cIsUtility>1</style> <style=cStack>(+1 per stack)</style> random enemy will be <style=cIsUtility>marked</style> for the same duration. Killing <style=cIsUtility>marked</style> enemies gives you <style=cIsDamage>+" + procDamage.ToString("N1") + " permanent base damage</style> <style=cStack>(up to a maximum of " + maxDamage.ToString("N1") + ")</style>.";
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public ItemIndex hitListTally {get; private set;}

--- a/Items/T3/Permafrost.cs
+++ b/Items/T3/Permafrost.cs
@@ -27,7 +27,7 @@ namespace ThinkInvisible.ClassicItems {
         
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Chance to freeze enemies on hit.";
-        protected override string NewLangDesc(string langid = null) => "<style=cIsUtility>" + Pct(procChance,1,1) + "</style> <style=cStack>(+" + Pct(procChance,1,1) + " per stack, inverse-mult.)</style> chance to <style=cIsUtility>freeze and slow</style> an enemy (" + freezeTime.ToString("N1") + " sec, " + slowTime.ToString("N1") + " sec). Affected by proc coefficient.";
+        protected override string NewLangDesc(string langid = null) => "<style=cIsUtility>" + Pct(procChance,1,1) + "</style> <style=cStack>(+" + Pct(procChance,1,1) + " per stack, inverse-multiplicative)</style> chance to <style=cIsUtility>freeze and slow</style> an enemy (" + freezeTime.ToString("N1") + "s and " + slowTime.ToString("N1") + "s respectively). Affected by proc coefficient.";
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public Permafrost() {

--- a/Items/T3/PhotonJetpack.cs
+++ b/Items/T3/PhotonJetpack.cs
@@ -39,7 +39,13 @@ namespace ThinkInvisible.ClassicItems {
 
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "No hands.";
-        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
+        protected override string NewLangDesc(string langid = null)
+        {
+            string desc = "Grants <style=cIsUtility>" + baseFuel.ToString("N1") + " second" + NPlur(baseFuel, 1) + "</style>";
+            if (stackFuel > 0f) desc += "<style=cStack>(+" + stackFuel.ToString("N1") + "s per stack)</style>";
+            desc += " of <style=cIsUtility>flight</style> at <style=cIsUtility>" + gravMod.ToString("N1") + "g</style> <style=cStack>(+" + fallBoost.ToString("N1") + "g while falling)</style>, usable once you have no double jumps remaining. Fuel <style=cIsUtility>recharges</style> at <style=cIsUtility>" + Pct(rchRate) + " speed</style> after a <style=cIsUtility>delay</style> of <style=cIsUtility>" + rchDelay.ToString("N0") + " second" + NPlur(rchDelay) + "</style>.";
+            return desc;
+        }
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public PhotonJetpack() {
@@ -148,14 +154,6 @@ namespace ThinkInvisible.ClassicItems {
             if(cpt.fuel>cpt.fuelCap) cpt.fuel=cpt.fuelCap;
             if(cpt.fuelCap == 0)
                 tgt.SetBuffCount(photonFuelBuff, 0);
-        }
-
-        private string FormatNewLangDesc()
-        {
-            string desc = "Grants <style=cIsUtility>" + baseFuel.ToString("N1") + " second" + NPlur(baseFuel, 1) + "</style>";
-            if (stackFuel > 0f) desc += "<style=cStack>(+" + stackFuel.ToString("N1") + "s per stack)</style>";
-            desc += " of <style=cIsUtility>flight</style> at <style=cIsUtility>" + gravMod.ToString("N1") + "g</style> <style=cStack>(+" + fallBoost.ToString("N1") + "g while falling)</style>, usable once you have no double jumps remaining. Fuel <style=cIsUtility>recharges</style> at <style=cIsUtility>" + Pct(rchRate) + " speed</style> after a <style=cIsUtility>delay</style> of <style=cIsUtility>" + rchDelay.ToString("N0") + " second" + NPlur(rchDelay) + "</style>.";
-            return desc;
         }
     }
 

--- a/Items/T3/PhotonJetpack.cs
+++ b/Items/T3/PhotonJetpack.cs
@@ -42,8 +42,8 @@ namespace ThinkInvisible.ClassicItems {
         protected override string NewLangDesc(string langid = null)
         {
             string desc = "Grants <style=cIsUtility>" + baseFuel.ToString("N1") + " second" + NPlur(baseFuel, 1) + "</style>";
-            if (stackFuel > 0f) desc += "<style=cStack>(+" + stackFuel.ToString("N1") + "s per stack)</style>";
-            desc += " of <style=cIsUtility>flight</style> at <style=cIsUtility>" + gravMod.ToString("N1") + "g</style> <style=cStack>(+" + fallBoost.ToString("N1") + "g while falling)</style>, usable once you have no double jumps remaining. Fuel <style=cIsUtility>recharges</style> at <style=cIsUtility>" + Pct(rchRate) + " speed</style> after a <style=cIsUtility>delay</style> of <style=cIsUtility>" + rchDelay.ToString("N0") + " second" + NPlur(rchDelay) + "</style>.";
+            if (stackFuel > 0f) desc += "<style=cStack>(+" + stackFuel.ToString("N1") + " seconds per stack)</style>";
+            desc += " of <style=cIsUtility>flight</style> at <style=cIsUtility>" + gravMod.ToString("N1") + "-g</style> <style=cStack>(+" + fallBoost.ToString("N1") + "-g while falling)</style>, usable once you have no double jumps remaining. Fuel <style=cIsUtility>recharges</style> at <style=cIsUtility>" + Pct(rchRate) + " speed</style> after a <style=cIsUtility>delay</style> of <style=cIsUtility>" + rchDelay.ToString("N0") + " second" + NPlur(rchDelay) + "</style>.";
             return desc;
         }
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";

--- a/Items/T3/PhotonJetpack.cs
+++ b/Items/T3/PhotonJetpack.cs
@@ -39,7 +39,7 @@ namespace ThinkInvisible.ClassicItems {
 
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "No hands.";
-        protected override string NewLangDesc(string langid = null) => "Grants <style=cIsUtility>" + baseFuel.ToString("N1") + " second" + NPlur(baseFuel, 1) + "</style> <style=cStack>(+" + stackFuel.ToString("N1") +" s per stack)</style> of <style=cIsUtility>flight</style> at <style=cIsUtility>" + gravMod.ToString("N1") + "g</style> <style=cStack>(+" + fallBoost.ToString("N1") + "g while falling)</style>, usable once you have no double jumps remaining. Fuel <style=cIsUtility>recharges</style> at <style=cIsUtility>" + Pct(rchRate) + " speed</style> after a <style=cIsUtility>delay</style> of <style=cIsUtility>" + rchDelay.ToString("N0") + " second" + NPlur(rchDelay) + "</style>.";
+        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public PhotonJetpack() {
@@ -148,6 +148,14 @@ namespace ThinkInvisible.ClassicItems {
             if(cpt.fuel>cpt.fuelCap) cpt.fuel=cpt.fuelCap;
             if(cpt.fuelCap == 0)
                 tgt.SetBuffCount(photonFuelBuff, 0);
+        }
+
+        private string FormatNewLangDesc()
+        {
+            string desc = "Grants <style=cIsUtility>" + baseFuel.ToString("N1") + " second" + NPlur(baseFuel, 1) + "</style>";
+            if (stackFuel > 0f) desc += "<style=cStack>(+" + stackFuel.ToString("N1") + "s per stack)</style>";
+            desc += " of <style=cIsUtility>flight</style> at <style=cIsUtility>" + gravMod.ToString("N1") + "g</style> <style=cStack>(+" + fallBoost.ToString("N1") + "g while falling)</style>, usable once you have no double jumps remaining. Fuel <style=cIsUtility>recharges</style> at <style=cIsUtility>" + Pct(rchRate) + " speed</style> after a <style=cIsUtility>delay</style> of <style=cIsUtility>" + rchDelay.ToString("N0") + " second" + NPlur(rchDelay) + "</style>.";
+            return desc;
         }
     }
 

--- a/Items/T3/TeleSight.cs
+++ b/Items/T3/TeleSight.cs
@@ -30,7 +30,13 @@ namespace ThinkInvisible.ClassicItems {
 
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Chance to instantly kill an enemy.";
-        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
+        protected override string NewLangDesc(string langid = null)
+        {
+            string desc = "<style=cIsDamage>" + Pct(procChance, 1, 1) + "</style>";
+            if (stackChance > 0f) desc += "<style=cStack>(+" + Pct(stackChance, 1, 1) + " per stack, up to " + Pct(capChance, 1, 1) + ")</style>";
+            desc += " chance to <style=cIsDamage>instantly kill</style> an enemy. Affected by proc coefficient.";
+            return desc;
+        }
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public TeleSight() {
@@ -83,14 +89,6 @@ namespace ThinkInvisible.ClassicItems {
                 target = vicb.mainHurtBox,
                 teamIndex = body.GetComponent<TeamComponent>()?.teamIndex ?? TeamIndex.Neutral
             });
-        }
-
-        private string FormatNewLangDesc()
-        {
-            string desc = "<style=cIsDamage>" + Pct(procChance, 1, 1) + "</style>";
-            if (stackChance > 0f) desc += "<style=cStack>(+" + Pct(stackChance, 1, 1) + " per stack, up to " + Pct(capChance, 1, 1) + ")</style>";
-            desc += " chance to <style=cIsDamage>instantly kill</style> an enemy. Affected by proc coefficient.";
-            return desc;
         }
     }
     

--- a/Items/T3/TeleSight.cs
+++ b/Items/T3/TeleSight.cs
@@ -30,7 +30,7 @@ namespace ThinkInvisible.ClassicItems {
 
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Chance to instantly kill an enemy.";
-        protected override string NewLangDesc(string langid = null) => "<style=cIsDamage>" + Pct(procChance,1,1) + "</style> <style=cStack>(+" + Pct(stackChance,1,1) + " per stack, up to " + Pct(capChance,1,1) + ")</style> chance to <style=cIsDamage>instantly kill</style> an enemy. Affected by proc coefficient.";
+        protected override string NewLangDesc(string langid = null) => FormatNewLangDesc();
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public TeleSight() {
@@ -83,6 +83,14 @@ namespace ThinkInvisible.ClassicItems {
                 target = vicb.mainHurtBox,
                 teamIndex = body.GetComponent<TeamComponent>()?.teamIndex ?? TeamIndex.Neutral
             });
+        }
+
+        private string FormatNewLangDesc()
+        {
+            string desc = "<style=cIsDamage>" + Pct(procChance, 1, 1) + "</style>";
+            if (stackChance > 0f) desc += "<style=cStack>(+" + Pct(stackChance, 1, 1) + " per stack, up to " + Pct(capChance, 1, 1) + ")</style>";
+            desc += " chance to <style=cIsDamage>instantly kill</style> an enemy. Affected by proc coefficient.";
+            return desc;
         }
     }
     

--- a/Items/TLunar/OldBox.cs
+++ b/Items/TLunar/OldBox.cs
@@ -27,7 +27,7 @@ namespace ThinkInvisible.ClassicItems {
         public bool requireHealth {get; private set;} = true;
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Chance to fear enemies when attacked.";
-        protected override string NewLangDesc(string langid = null) => "<style=cDeath>When hit for more than " + Pct(healthThreshold) + " max health</style> <style=cStack>(/2 per stack)</style>, <style=cIsUtility>fear enemies</style> within <style=cIsUtility>" + radius.ToString("N0") + " m</style> for <style=cIsUtility>" + duration.ToString("N1") + " seconds</style>. <style=cIsUtility>Feared enemies will run out of melee</style>, <style=cDeath>but that won't stop them from shooting you.</style>";
+        protected override string NewLangDesc(string langid = null) => "<style=cDeath>When hit for more than " + Pct(healthThreshold) + " max health</style> <style=cStack>(/2 per stack)</style>, <style=cIsUtility>fear enemies</style> within <style=cIsUtility>" + radius.ToString("N0") + " m</style> for <style=cIsUtility>" + duration.ToString("N1") + " seconds</style>. <style=cIsUtility>Feared enemies will run away</style>, <style=cDeath>but that won't stop them from performing ranged attacks</style>.";
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public OldBox() {

--- a/Items/TLunar/OldBox.cs
+++ b/Items/TLunar/OldBox.cs
@@ -27,7 +27,7 @@ namespace ThinkInvisible.ClassicItems {
         public bool requireHealth {get; private set;} = true;
         protected override string NewLangName(string langid = null) => displayName;
         protected override string NewLangPickup(string langid = null) => "Chance to fear enemies when attacked.";
-        protected override string NewLangDesc(string langid = null) => "<style=cDeath>When hit for more than " + Pct(healthThreshold) + " max health</style> <style=cStack>(/2 per stack)</style>, <style=cIsUtility>fear enemies</style> within <style=cIsUtility>" + radius.ToString("N0") + " m</style> for <style=cIsUtility>" + duration.ToString("N1") + " seconds</style>. <style=cIsUtility>Feared enemies will run away</style>, <style=cDeath>but that won't stop them from performing ranged attacks</style>.";
+        protected override string NewLangDesc(string langid = null) => "<style=cDeath>When hit for more than " + Pct(healthThreshold) + " max health</style> <style=cStack>(/2 per stack)</style>, <style=cIsUtility>fear enemies</style> within <style=cIsUtility>" + radius.ToString("N0") + " m</style> for <style=cIsUtility>" + duration.ToString("N1") + " seconds</style>. <style=cIsUtility>Feared enemies will run out of melee</style>, <style=cDeath>but that won't stop them from performing ranged attacks</style>.";
         protected override string NewLangLore(string langid = null) => "A relic of times long past (ClassicItems mod)";
 
         public OldBox() {


### PR DESCRIPTION
This is just an improvement for `NewLangPickup` and `NewLangDesc` found on items.

e.g. Remove `(+0 damage per stack)` if the bonus is `0`. Display otherwise if it's greater than `0`.